### PR TITLE
Couple of fixes

### DIFF
--- a/lib/index/withPosition.js
+++ b/lib/index/withPosition.js
@@ -5,7 +5,6 @@
  */
 
 import IdxInterface from './interface.js';
-import elasticlunr from '../elasticlunr.js';
 
 function levenshteinDistance(a, b) {
   // Create empty edit distance matrix for all possible modifications of

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "coveralls": "^3.0.7",
     "cross-env": "^5.2.0",
     "doxx": "1.4.0",
-    "elasticlunr": "0.9.5",
     "eslint": "^5.0.1",
     "eslint-loader": "^2.0.0",
     "jest": "^24.9.0",


### PR DESCRIPTION
- I forgot to remove a definition of `elasticlunr` in the main `package.json` file, which led to the integration tests... working on the old version! At least we're sure that everything works on the old and the new.
- Since the default `expandFields` implementation no longer requires pipelines, we don't need the definition of `elasticlunr` in the index source